### PR TITLE
Added Safe-Portals, Addresses NerdBugs #31

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -8,6 +8,7 @@ block-caps: true
 remove-on-exit: false
 animal-count: false
 safe-dispensers: false
+safe-portals: false
 safe-boats: true
 safe-boats-delay: 6000
 safe-boats-drop: true

--- a/src/nu/nerd/kitchensink/Configuration.java
+++ b/src/nu/nerd/kitchensink/Configuration.java
@@ -25,6 +25,7 @@ public class Configuration
     public boolean ANIMAL_COUNT;
     public int PEARL_DAMAGE;
     public boolean SAFE_ICE;
+    public boolean SAFE_PORTALS;
 
     public List<Integer> DISABLE_DISPENSED;
     public List<Integer> DISABLED_LEFT_ITEMS;
@@ -57,6 +58,7 @@ public class Configuration
         SAFE_MINECARTS = plugin.getConfig().getBoolean("safe-minecarts");
         SAFE_MINECARTS_DELAY = plugin.getConfig().getInt("safe-minecarts-delay");
         SAFE_MINECARTS_DROP = plugin.getConfig().getBoolean("safe-minecarts-drop");
+        SAFE_PORTALS = plugin.getConfig().getBoolean("safe-portals");
         DISABLED_LEFT_ITEMS = plugin.getConfig().getIntegerList("disabled-items.left-click");
         DISABLED_RIGHT_ITEMS = plugin.getConfig().getIntegerList("disabled-items.right-click");
         DISABLE_DISPENSED = plugin.getConfig().getIntegerList("disable-dispensed");

--- a/src/nu/nerd/kitchensink/KitchenSinkListener.java
+++ b/src/nu/nerd/kitchensink/KitchenSinkListener.java
@@ -24,6 +24,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.player.PlayerShearEntityEvent;
 import org.bukkit.event.vehicle.VehicleExitEvent;
+import org.bukkit.event.world.PortalCreateEvent;
 import org.bukkit.inventory.ItemStack;
 
 class KitchenSinkListener implements Listener {
@@ -158,6 +159,15 @@ class KitchenSinkListener implements Listener {
         }
     }
     
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPortalCreate(PortalCreateEvent event) {
+        if (event.isCancelled())
+            return;
+        
+        if (plugin.config.SAFE_PORTALS)
+            event.setCancelled(true);
+    }
+
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onBlockBreak(BlockBreakEvent event) {
         if(event.isCancelled()) {


### PR DESCRIPTION
https://github.com/NerdNu/NerdBugs/issues/31

Blocks Ignition of Portal by cancelling:
PortalCreateEvent

Tested against latest CraftBukkit RB(1.3.1 R.2.0).
Tested against Flint and Steel & Fire Charges on Portal.
Tested against Dispensers shooting Fire Charges at Portal.
Tested against Blazes firing upon Portal.

May need to be Tested against:
Ghast fireballs(should work, but never hurts to check)
lava/burning wood block in portal(the wood in portal threw up the event when testing, so it should be blocked.)
Any other method of lighting a Portal.
