### PR TITLE
Added ability to remove invisibility PotionEffect when an invisible player is struck in combat

### DIFF
--- a/src/nu/nerd/kitchensink/KitchenSinkListener.java
+++ b/src/nu/nerd/kitchensink/KitchenSinkListener.java
@@ -250,8 +250,11 @@ class KitchenSinkListener implements Listener {
                 if(damagerPlayer.hasPotionEffect(PotionEffectType.INVISIBILITY)){
                     damagerPlayer.removePotionEffect(PotionEffectType.INVISIBILITY);
                 }
+                
+                if(((Player)event.getEntity()).hasPotionEffect(PotionEffectType.INVISIBILITY)){
+                    ((Player)event.getEntity()).removePotionEffect(PotionEffectType.INVISIBILITY);
+            	}
             }
-            
             else if(event.getDamager() instanceof Projectile){
                 Projectile damageProjectile = (Projectile)event.getDamager();
                 
@@ -260,12 +263,14 @@ class KitchenSinkListener implements Listener {
                     if(damagerPlayer.hasPotionEffect(PotionEffectType.INVISIBILITY)){
                         damagerPlayer.removePotionEffect(PotionEffectType.INVISIBILITY);
                     }
+                    
+                    if(((Player)event.getEntity()).hasPotionEffect(PotionEffectType.INVISIBILITY)){
+                    	((Player)event.getEntity()).removePotionEffect(PotionEffectType.INVISIBILITY);
+            	    }
                 }
             }
             
-            if(((Player)event.getEntity()).hasPotionEffect(PotionEffectType.INVISIBILITY)){
-                    ((Player)event.getEntity()).removePotionEffect(PotionEffectType.INVISIBILITY);
-            }
+            
         }
         
     }


### PR DESCRIPTION
Uses the same setting as the previous commit - just a slight modification.

Adresses NerdNu/NerdBugs#61.
