### PR TITLE
Added option to undo strength potion changes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,6 +6,7 @@ buff-shear-drops: 0
 disable-snowgrow: false
 disable-drops: false
 disable-invisibility-on-combat: false
+lower-strength-potion-damage: false
 block-caps: true
 block-villagers: false
 safe-ice: false

--- a/src/nu/nerd/kitchensink/Configuration.java
+++ b/src/nu/nerd/kitchensink/Configuration.java
@@ -13,6 +13,7 @@ public class Configuration {
 	public boolean DISABLE_SNOW;
 	public boolean DISABLE_DROPS;
 	public boolean DISABLE_INVISIBILITY_ON_COMBAT;
+	public boolean LOWER_STRENGTH_POTION_DAMAGE;
 	public boolean BLOCK_CAPS;
 	public boolean BLOCK_VILLAGERS;
 	public boolean SAFE_ICE;
@@ -60,6 +61,7 @@ public class Configuration {
 		DISABLE_SNOW = plugin.getConfig().getBoolean("disable-snowgrow");
 		DISABLE_DROPS = plugin.getConfig().getBoolean("disable-drops");
 		DISABLE_INVISIBILITY_ON_COMBAT = plugin.getConfig().getBoolean("disable-invisibility-on-combat");
+		LOWER_STRENGTH_POTION_DAMAGE = plugin.getConfig().getBoolean("lower-strength-potion-damage");
 		BLOCK_CAPS = plugin.getConfig().getBoolean("block-caps");
 		BLOCK_VILLAGERS = plugin.getConfig().getBoolean("block-villagers");
 		SAFE_ICE = plugin.getConfig().getBoolean("safe-ice");

--- a/src/nu/nerd/kitchensink/KitchenSinkListener.java
+++ b/src/nu/nerd/kitchensink/KitchenSinkListener.java
@@ -48,6 +48,7 @@ import org.bukkit.event.world.PortalCreateEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
+import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
 class KitchenSinkListener implements Listener {
@@ -352,6 +353,24 @@ class KitchenSinkListener implements Listener {
 
 					if (((Player) event.getEntity()).hasPotionEffect(PotionEffectType.INVISIBILITY)) {
 						((Player) event.getEntity()).removePotionEffect(PotionEffectType.INVISIBILITY);
+					}
+				}
+			}
+		}
+		if(plugin.config.LOWER_STRENGTH_POTION_DAMAGE && event.getEntity() instanceof Player && event.getDamager() instanceof Player) {
+			Player damager = (Player) event.getDamager();
+			if (damager.hasPotionEffect(PotionEffectType.INCREASE_DAMAGE)) {
+				for (PotionEffect pe : damager.getActivePotionEffects()){
+					if (pe.getType().equals(PotionEffectType.INCREASE_DAMAGE)) {
+						double newDamage = event.getDamage();
+						if (pe.getAmplifier() == 1) { //str2
+							newDamage = newDamage / 2.6;
+							newDamage = newDamage + 6;
+						} else if (pe.getAmplifier() == 0) { //str1
+							newDamage = newDamage / 1.3;
+							newDamage = newDamage + 3;
+						}
+						event.setDamage(newDamage);
 					}
 				}
 			}


### PR DESCRIPTION
This should fix NerdNu/NerdBugs#140, this change removes the damage increase to Strength 1 and 2 potions. 

According to [this](http://www.minecraftwiki.net/index.php?title=Status_effect&oldid=509091) wiki page (1.5.2), and [this](http://www.minecraftwiki.net/index.php?title=Status_effect&oldid=512125) wiki page [1.6.2], strength 2 in 1.5 was simply 3 extra damage (or 6 extra damage, with strength 2), whereas strength 2 in 1.6 is a 130%/160% increase on base weapon damage. 

Bukkit does not have an attribute API finished as of right now. I did not see the purpose of including a way to change the attributes of the strength 2 potions using NMS and org.bukkit.craftbukkit, as those are more likely to change/break between versions. I'll look at reimplementing this when the Attribute API is released.

Thanks.
