### PR TITLE
Added option to buff health potions to original 1.5 amount

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -5,6 +5,7 @@ buff-drops: 0
 buff-shear-drops: 0
 disable-snowgrow: false
 disable-drops: false
+buff-health-potions: false
 disable-invisibility-on-combat: false
 lower-strength-potion-damage: false
 block-caps: true

--- a/src/nu/nerd/kitchensink/Configuration.java
+++ b/src/nu/nerd/kitchensink/Configuration.java
@@ -12,6 +12,7 @@ public class Configuration {
 	public int BUFF_SHEAR_DROPS;
 	public boolean DISABLE_SNOW;
 	public boolean DISABLE_DROPS;
+	public boolean BUFF_HEALTH_POTIONS;
 	public boolean DISABLE_INVISIBILITY_ON_COMBAT;
 	public boolean LOWER_STRENGTH_POTION_DAMAGE;
 	public boolean BLOCK_CAPS;
@@ -62,6 +63,7 @@ public class Configuration {
 		DISABLE_SNOW = plugin.getConfig().getBoolean("disable-snowgrow");
 		DISABLE_DROPS = plugin.getConfig().getBoolean("disable-drops");
 		DISABLE_INVISIBILITY_ON_COMBAT = plugin.getConfig().getBoolean("disable-invisibility-on-combat");
+		BUFF_HEALTH_POTIONS = plugin.getConfig().getBoolean("buff-health-potions");
 		LOWER_STRENGTH_POTION_DAMAGE = plugin.getConfig().getBoolean("lower-strength-potion-damage");
 		BLOCK_CAPS = plugin.getConfig().getBoolean("block-caps");
 		BLOCK_VILLAGERS = plugin.getConfig().getBoolean("block-villagers");

--- a/src/nu/nerd/kitchensink/KitchenSinkListener.java
+++ b/src/nu/nerd/kitchensink/KitchenSinkListener.java
@@ -31,6 +31,8 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.EntityBlockFormEvent;
 import org.bukkit.event.block.BlockDispenseEvent;
 import org.bukkit.event.enchantment.PrepareItemEnchantEvent;
+import org.bukkit.event.entity.EntityRegainHealthEvent;
+import org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
@@ -384,6 +386,21 @@ class KitchenSinkListener implements Listener {
 				event.setCancelled(true);
 			}
 		}
+	}
+
+	@EventHandler
+
+	public void health (EntityRegainHealthEvent event){
+		if (plugin.config.BUFF_HEALTH_POTIONS){
+			if(event.getEntity() instanceof Player){
+				if(event.getRegainReason() == RegainReason.MAGIC){
+					double amount = (event.getAmount()*1.5);
+					event.setAmount(amount);
+				}
+			}
+
+		}
+
 	}
 
 	@EventHandler(priority = EventPriority.HIGHEST)


### PR DESCRIPTION
This was NOT requested by an admin, but a player. I am simply adding this on the off chance it is decided we want to do this later, the code to do so is finished. 

Code taken from [here](http://www.reddit.com/r/MineZ/comments/1hx9fc/162_potions_message_to_the_developers/cayuthd), and suggested by IDANUB [here](https://nerd.nu/forum/index.php?/topic/588-vanilla-pvp-is-broken-in-16/#entry4614). 

If you choose to include it, please set the config to false on survival until it is decided that this is needed by one of the s-admins/the community/whoever decides these things. Thanks!
