### PR TITLE
Add disable-tnt option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Configuration:
 * *buff-shear-drops* Increase wool dropped by sheared sheep by factor
 * *disable-snowgrow* Disable snow being generated
 * *disable-drops* Disable items, great for creative servers
+* *disable-tnt* Disable TNT from being ignited
 * *disable-invisibility-on-combat* Remove invisibility potion effects when a player PvPs.
 * *lower-strength-potion-damage* Reduce damage dealt with strength potions to Minecraft 1.5 levels.
 * *health-potion-multiplier* The multiplicative factor applied to health from instant health potions (splashed and drunk).

--- a/config.yml
+++ b/config.yml
@@ -5,6 +5,7 @@ buff-drops: 0
 buff-shear-drops: 0
 disable-snowgrow: false
 disable-drops: false
+disable-tnt: false
 disable-invisibility-on-combat: false
 lower-strength-potion-damage: false
 health-potion-multiplier: 1.0

--- a/src/nu/nerd/kitchensink/Configuration.java
+++ b/src/nu/nerd/kitchensink/Configuration.java
@@ -12,6 +12,7 @@ public class Configuration {
 	public int BUFF_SHEAR_DROPS;
 	public boolean DISABLE_SNOW;
 	public boolean DISABLE_DROPS;
+	public boolean DISABLE_TNT;
 	public boolean DISABLE_INVISIBILITY_ON_COMBAT;
 	public boolean LOWER_STRENGTH_POTION_DAMAGE;
 	public double HEALTH_POTION_MULTIPLIER;
@@ -68,6 +69,7 @@ public class Configuration {
 		BUFF_SHEAR_DROPS = plugin.getConfig().getInt("buff-shear-drops");
 		DISABLE_SNOW = plugin.getConfig().getBoolean("disable-snowgrow");
 		DISABLE_DROPS = plugin.getConfig().getBoolean("disable-drops");
+		DISABLE_TNT = plugin.getConfig().getBoolean("disable-tnt");
 		DISABLE_INVISIBILITY_ON_COMBAT = plugin.getConfig().getBoolean("disable-invisibility-on-combat");
 		LOWER_STRENGTH_POTION_DAMAGE = plugin.getConfig().getBoolean("lower-strength-potion-damage");
 		HEALTH_POTION_MULTIPLIER = plugin.getConfig().getDouble("health-potion-multiplier", 1.0);

--- a/src/nu/nerd/kitchensink/KitchenSinkListener.java
+++ b/src/nu/nerd/kitchensink/KitchenSinkListener.java
@@ -35,7 +35,9 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockBurnEvent;
 import org.bukkit.event.block.BlockDispenseEvent;
+import org.bukkit.event.block.BlockPhysicsEvent;
 import org.bukkit.event.block.EntityBlockFormEvent;
 import org.bukkit.event.enchantment.PrepareItemEnchantEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
@@ -192,6 +194,23 @@ class KitchenSinkListener implements Listener {
 				event.setCancelled(true);
 			}
 		}
+		
+		if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+			if (plugin.config.DISABLE_TNT) {
+				if (stack.getType() == Material.FLINT_AND_STEEL && event.getClickedBlock().getType() == Material.TNT) {
+					event.setCancelled(true);
+				}
+			}
+		}
+	}
+	
+	@EventHandler(priority = EventPriority.HIGHEST)
+	public void onBlockBurn(BlockBurnEvent event) {
+		if (plugin.config.DISABLE_TNT) {
+			if (event.getBlock().getType() == Material.TNT) {
+				event.setCancelled(true);
+			}
+		}
 	}
 
 	@EventHandler(priority = EventPriority.NORMAL)
@@ -340,6 +359,15 @@ class KitchenSinkListener implements Listener {
 	public void onBlockDispense(BlockDispenseEvent event) {
 		if (plugin.config.SAFE_DISPENSERS) {
 			if (plugin.config.DISABLE_DISPENSED.contains(event.getItem().getTypeId())) {
+				event.setCancelled(true);
+			}
+		}
+	}
+	
+	@EventHandler(priority = EventPriority.HIGHEST)
+	public void onBlockPhysics(BlockPhysicsEvent event) {
+		if (plugin.config.DISABLE_TNT) {
+			if (event.getBlock().getType() == Material.TNT) {
 				event.setCancelled(true);
 			}
 		}


### PR DESCRIPTION
Prevent TNT from being ignited by redstone, flint and steel, or fire spread. If we enable bows, ignition by flame arrows isn't able to be prevented using the current CraftBukkit API.
