### PR TITLE
Now with added sarcasm!!1!

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>nu.nerd</groupId>
 	<artifactId>KitchenSink</artifactId>
-	<version>0.7</version>
+	<version>0.7.1</version>
 	<packaging>jar</packaging>
 	<name>KitchenSink</name>
 	<properties>

--- a/src/nu/nerd/kitchensink/KitchenSinkListener.java
+++ b/src/nu/nerd/kitchensink/KitchenSinkListener.java
@@ -350,9 +350,13 @@ class KitchenSinkListener implements Listener {
         }
 
         String message = event.getMessage();
+        boolean sarcasmDetected = message.startsWith(ChatColor.ITALIC.toString());
         message = ChatColor.stripColor(message);
         message = message.replaceAll(REPLACED_CHARS, " ");
         message = Normalizer.normalize(message, Normalizer.Form.NFD);
+        if (sarcasmDetected) {
+            message = ChatColor.ITALIC + message;
+        }
         event.setMessage(message);
 
         if (plugin.config.BLOCK_CAPS) {


### PR DESCRIPTION
My CH /s (sarcasm) command was inadvertently tested with KitchenSink disabled.  KitchenSink intercepts the player chat created by /s and strips formatting from it.  This pull reinstates the italics (only).

Commit Message:

The chat spam filter in onPlayerChat() removes all colour codes from players'
chat messages.  (This is why we can't have nice things.)  Unfortunately, this
strips italics from chat messages created using /s (sarcasm).  This patch
detects italics at the start of a chat message and adds it back in after the
message is stripped of formatting.

An alternative solution would have been to change the /s CH script to broadcast
the message instead, bypassing the onPlayerChat() event.  However, I expect that
would have had the undesirable side-effect of allowing /s to bypass /ignore,
where that is enabled.
