### PR TITLE
Allow for all caps usernames in chat

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>nu.nerd</groupId>
   <artifactId>KitchenSink</artifactId>
   <name>KitchenSink</name>
-  <version>0.7</version>
+  <version>0.8.2</version>
   <build>
     <sourceDirectory>${basedir}/src</sourceDirectory>
     <defaultGoal>clean package</defaultGoal>

--- a/src/nu/nerd/kitchensink/KitchenSinkListener.java
+++ b/src/nu/nerd/kitchensink/KitchenSinkListener.java
@@ -375,12 +375,11 @@ class KitchenSinkListener implements Listener {
 
         if (plugin.config.BLOCK_CAPS) {
             int upperCount = 0;
-            String stMessage = message;
             for(Player p : plugin.getServer().getOnlinePlayers()) {
-                stMessage = stMessage.replace(p.getName(),"");
+                message = message.replace(p.getName(),"");
             }
-            for (int i = 0; i < stMessage.length(); i++) {
-                if (Character.isUpperCase(stMessage.charAt(i))) {
+            for (int i = 0; i < message.length(); i++) {
+                if (Character.isUpperCase(message.charAt(i))) {
                     upperCount++;
                 }
             }


### PR DESCRIPTION
The method that was checking to see if someone was typing in too many caps now checks to see if the string contains a username. If so, it doesn't count those caps towards the total.
