### PR TITLE
Fixed caps block bypass possibility from using "invisible" unicode characters

### DIFF
--- a/src/nu/nerd/kitchensink/KitchenSinkListener.java
+++ b/src/nu/nerd/kitchensink/KitchenSinkListener.java
@@ -376,16 +376,21 @@ class KitchenSinkListener implements Listener {
 
         if (plugin.config.BLOCK_CAPS) {
             int upperCount = 0;
+            int messageLength = 0;
             for(Player p : plugin.getServer().getOnlinePlayers()) {
                 message = message.replace(p.getName(),"");
             }
-            for (int i = 0; i < message.length(); i++) {
-                if (Character.isUpperCase(message.charAt(i))) {
+			
+            for (char c : message.toCharArray()) {
+                if (Character.isUpperCase(c)) {
                     upperCount++;
+                }
+                if (Character.isLetter(c) || c == ' ') {
+                    messageLength++;
                 }
             }
 
-            if ((upperCount > message.length() / 2) && message.length() > 8) {
+            if ((upperCount > messageLength / 2) && messageLength > 8) {
                 event.getPlayer().sendMessage(ChatColor.DARK_GREEN + "Please don't type in all caps.");
                 event.setCancelled(true);
             }


### PR DESCRIPTION
Hopefully fixes the bug that allows users to spam caps with a bunch of unicode symbols that Minecraft doesn't render in order to get around the caps block.